### PR TITLE
Add Developer Custom Metric Tracking to Dashboard

### DIFF
--- a/Frontend/src/data/mockUserMetrics.js
+++ b/Frontend/src/data/mockUserMetrics.js
@@ -1,0 +1,14 @@
+/*
+    Mock user metrics data
+    Used until Okta authentication is implemented
+*/
+
+export const assignedMetricsMock = [
+    "average_time_to_close",
+    "average_time_to_merge"
+];
+
+export const availableMetricsMock = [
+    "total_commits",
+    "total_prs"
+];

--- a/Frontend/src/features/home/routes/Home.jsx
+++ b/Frontend/src/features/home/routes/Home.jsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import VolumeCharts from "../../../components/charts/VolumeBased";
 import { transformVolumeData } from "../../../utils/TransformVolumeData";
 import TimeBased from "../../../components/charts/TimeBased";
@@ -5,23 +6,69 @@ import { calculateOrgAverage } from "../../../utils/TransformTimeData";
 import { getTopContributorsAndRepos } from "../../../utils/getTopContributorsAndRepos";
 import lifetimeData from "../../../../../data/lifetime_data.json";
 import "./Home.css";
+import { availableMetricsMock } from "../../../data/mockUserMetrics";
 /*
     Main Home dashboard view displaying high-level organization metrics.
     Returns:
         JSX.Element: The Home dashboard component.
 */
 export const Home = () => {
+  /* 
+    Transform lifetime data into volume chart format
+  */
   const orgVolumeData = transformVolumeData(lifetimeData, 'org', null, "All");
 
+  /*
+    Calculate organization-level time-based metrics
+  */
   const orgAvgClose = calculateOrgAverage(lifetimeData, "issues", "average_time_to_close");
   const orgAvgMerge = calculateOrgAverage(lifetimeData, "pull_requests", "average_time_to_merge");
 
-  const orgTimeBasedData = [
+  /*
+    Assigned metrics are provided by tech leads
+  */
+  const assignedMetrics = [
     { label: "Avg Time to Close (Issues)", value: orgAvgClose },
     { label: "Avg Time to Merge (PRs)", value: orgAvgMerge },
   ];
 
-  // 2. Call your utility function right here to get the top 5
+  /*
+    Custom metrics added by developer
+    Starts empty and updates dynamically
+  */
+  const [customMetrics, setCustomMetrics] = useState([]);
+
+  /*
+    Convert mock metric names into displayable metric objects
+  */
+  const availableMetrics = availableMetricsMock.map(metric => {
+    if (metric === "total_commits") {
+      return { label: "Total Commits", value: orgVolumeData[0]?.value || 0 };
+    }
+    if (metric === "total_prs") {
+      return { label: "Total PRs", value: orgVolumeData[1]?.value || 0 };
+    }
+    return null;
+  }).filter(Boolean);
+
+  /*
+    Handles adding a new custom metric
+  */
+  const handleAddMetric = () => {
+    const remainingMetrics = availableMetrics.filter(
+      metric => !customMetrics.find(m => m.label === metric.label)
+    );
+
+    if (remainingMetrics.length === 0) return;
+
+    const nextMetric = remainingMetrics[0];
+
+    setCustomMetrics([...customMetrics, nextMetric]);
+  };
+
+  /*
+    Get top contributors and repositories
+  */
   const { topContributors, topRepos } = getTopContributorsAndRepos(lifetimeData, 12);
 
   return (
@@ -82,14 +129,15 @@ export const Home = () => {
           </div>
         </section>
       </div>
+      {/* Handbook / Links Section */}
       <div className="home-grid">
         <div className="handbook-column">
+
           <a href="https://docs.google.com/forms/d/e/1FAIpQLSdZF2zfa72ei0rg52cEIh0vpFiOKDmf27oF1DF2E3Oaf1Jhzg/viewform" target="_blank" rel="noreferrer" className="handbook-card">
             <div className="handbook-icon">📄</div>
             <div className="handbook-text">FEEDBACK FORM</div>
           </a>
-      <div className="home-grid">
-        <div className="handbook-column">
+      
           <a href="https://github.com/oss-slu/handbook_developer" target="_blank" rel="noreferrer" className="handbook-card">
             <div className="handbook-icon">📄</div>
             <div className="handbook-text">DEVELOPER HANDBOOK</div>
@@ -100,18 +148,45 @@ export const Home = () => {
             <div className="handbook-text">TECH LEAD HANDBOOK</div>
           </a>
         </div>
-        </div>
-        </div>
-
-        <section className="card-blue">
-          <h2 className="card-title">Time-based Metrics</h2>
-          <div className="chart-wrapper">
-            <TimeBased data={orgTimeBasedData} repos="All" />
-          </div>
-        </section>
       </div>
 
-    </div>
+        {/* Assigned Metrics Section */}
+        <section className="card-blue">
+          <h2 className="card-title">Assigned Metrics</h2>
 
+          <div className="chart-wrapper">
+            <TimeBased data={assignedMetrics} repos="All" />
+          </div>
+        </section>
+
+        {/* Custom Metrics Section */}
+        <section className="card-blue">
+          <h2 className="card-title">Custom Metrics</h2>
+
+          {/* Add Metric Button */}
+          <button
+            onClick={handleAddMetric}
+            style={{
+              marginBottom: "10px",
+              padding: "6px 12px",
+              backgroundColor: "#123f8b",
+              color: "white",
+              border: "none",
+              borderRadius: "6px",
+              cursor: "pointer"
+            }}
+          >
+            + Add Metric
+          </button>
+
+          <div className="chart-wrapper">
+            {customMetrics.length > 0 ? (
+              <TimeBased data={customMetrics} repos="All" />
+            ) : (
+              <p style={{ color: "#4b5563" }}>No custom metrics added</p>
+            )}
+          </div>
+        </section>
+    </div>  
   );
 };


### PR DESCRIPTION
# Description
Implemented custom metric tracking for developers on the Home dashboard.
Added a separate section for Custom Metric so developers can add their own metrics in addition to the assigned ones. Since Okta is not implemented yet, I used mock data to simulate this functionality.
Also made sure that metrics are added dynamically and duplicates are not allowed. Existing chart components were reused to keep consistency with the current UI.

Fixes #165 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Tested locally using the dev server.

Steps:
1. Ran npm run dev
2. Opened the Home dashboard
3. Clicked on "+ Add Metric" in the Custom Metrics section.

Observed that:
- Metrics get added to the chart
- Clicking again adds the next available metric
- No duplicate metrics are added
- Assigned metrics still display correctly

**Test Configuration**:
* Language Version: JavaScript (React + Vite)
* Webpage (if applicable): http://localhost:5173/

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Screenshot of Output
<img width="1370" height="793" alt="image" src="https://github.com/user-attachments/assets/10316a0d-f4fb-47dc-93e5-8eafb0c12bca" />
