### PR TITLE
Fix: Alphabetize Repo Dropdown

### DIFF
--- a/Frontend/src/features/team-stats/components/teamStatsSidebar.jsx
+++ b/Frontend/src/features/team-stats/components/teamStatsSidebar.jsx
@@ -66,7 +66,14 @@ const TeamStatsSidebar = ({
               }}
             >
               {[...TEAMS]
-                .sort((a, b) => a.localeCompare(b)) // Sort alphabetically
+                .sort((a, b) => {
+                  // Keeping "All Teams" at the top
+                  if (a === "All Teams") return -1;
+                  if (b === "All Teams") return 1;
+
+                  // Sort the rest alphabetically
+                  return a.localeCompare(b);
+                })
                 .map((t, index) => (
                   <option key={`repo-${index}`} value={t}>
                     {t}

--- a/Frontend/src/features/team-stats/components/teamStatsSidebar.jsx
+++ b/Frontend/src/features/team-stats/components/teamStatsSidebar.jsx
@@ -42,7 +42,13 @@ const TeamStatsSidebar = ({
         <div className="sidebar-section">
           <label className="sidebar-label">Team</label>
           <select className="sidebar-select" value={selectedTeam} onChange={(e) => setSelectedTeam(e.target.value)}>
-            {TEAMS.map((t, index) => <option key={`team-${index}`} value={t}>{t}</option>)}
+            {[...TEAMS]
+              .sort((a, b) => a.localeCompare(b)) // Sort alphabetically
+              .map((t, index) => (
+                <option key={`team-${index}`} value={t}>
+                  {t}
+                </option>
+              ))}
           </select>
         </div>
       )}
@@ -59,7 +65,13 @@ const TeamStatsSidebar = ({
                 setSelectedUser("all");
               }}
             >
-              {TEAMS.map((t, index) => <option key={`repo-${index}`} value={t}>{t}</option>)}
+              {[...TEAMS]
+                .sort((a, b) => a.localeCompare(b)) // Sort alphabetically
+                .map((t, index) => (
+                  <option key={`repo-${index}`} value={t}>
+                    {t}
+                  </option>
+                ))}
             </select>
           </div>
 


### PR DESCRIPTION
# Description
Fixed the repository dropdown in the Team page so that the repos are shown in alphabetical order instead of random order. This makes it easier to find and select a repo.

Fixes #185 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Ran the app locally and checked the Team Stats page.
Steps:
- opened the app using npm run dev
- went to Team Stats page
- switched to User View
- opened the repository dropdown
Verified that the repos are now sorted alphabetically and selection works fine.

**Test Configuration**:
* Language Version: JavaScript (React)
* Webpage (if applicable): Team Stats page

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Screenshot of Output
<img width="244" height="551" alt="image" src="https://github.com/user-attachments/assets/33f6491e-1584-48aa-9d2e-d783fbba7415" />