### PR TITLE
Feature/issue 186 remove inactive users

### DIFF
--- a/Backend/dataCollection/formatJSON.py
+++ b/Backend/dataCollection/formatJSON.py
@@ -1,6 +1,7 @@
 
 import numpy as np
 import pandas as pd
+from Backend.streakCalculation import calculate_current_streak
 
 
 def format_json_data(raw_data, sprint = -1):
@@ -44,11 +45,17 @@ def format_json_data(raw_data, sprint = -1):
             avg_time_to_close = group['lead_time'].mean()
             total_issues_opened = len(group)
             total_issues_closed = group['state'].value_counts().get('closed', 0)
+            if 'closed_at' in group.columns:
+                closed_issue_dates = group[group['state'] == 'closed']['closed_at'].dropna().tolist()
+            else:
+                closed_issue_dates = []
+            current_streak = calculate_current_streak(closed_issue_dates)
 
             formatted_data['issues'][user] = {
                 "average_time_to_close": avg_time_to_close if not np.isnan(avg_time_to_close) else 0,
                 "total_issues_opened": total_issues_opened,
-                "total_issues_closed": total_issues_closed
+                "total_issues_closed": total_issues_closed,
+                "currentStreak": current_streak
             }
 
     #Process Pull Requests

--- a/Backend/streakCalculation.py
+++ b/Backend/streakCalculation.py
@@ -1,0 +1,87 @@
+from datetime import datetime, timedelta
+
+ISSUE_THRESHOLD = 3
+
+def get_week_start(date_obj):
+    """
+    Returns the Monday of the week for a given data
+    """
+    return (date_obj - timedelta(days=date_obj.weekday())).date()
+
+def parse_closed_dates(closed_issue_dates):
+    """
+    Converts a list of date strings or datetime objects into datetime objects
+    Skips invalid or empty values
+    """
+    parsed_dates = []
+
+    for value in closed_issue_dates:
+        if not value:
+            continue
+
+        if isinstance(value, datetime):
+            parsed_dates.append(value)
+            continue
+
+        try:
+            parsed_dates.append(datetime.fromisoformat(value.replace("Z", "+00:00")))
+        except (ValueError, AttributeError):
+            continue
+
+    return parsed_dates
+
+def group_issues_by_week(closed_issue_dates):
+    """
+    Counts how many issues were closed in each week
+    Returns a dictionary like:
+    {
+        week_start_date: count
+    }
+    """
+    weekly_counts = {}
+
+    parsed_dates = parse_closed_dates(closed_issue_dates)
+
+    for closed_date in parsed_dates:
+        week_start = get_week_start(closed_date)
+        weekly_counts[week_start] = weekly_counts.get(week_start, 0) + 1
+
+    return weekly_counts
+
+def calculate_current_streak(closed_issue_dates, threshold=ISSUE_THRESHOLD, reference_date=None):
+    """
+    Calculates the active streak based on weekly issue closure threshold
+
+    A streak increases by 1 for every consecutive week where
+    the number of closed issues meets or exceeds the threshold
+
+    Args:
+        closed_issue_dates: list of datetime objects or ISO date strings
+        threshold: minimum number of issues closed in a week
+        reference_date: optional datetime to use instead of current time
+
+    Returns:
+        int: current streak count
+    """
+    if reference_date is None:
+        reference_date = datetime.now()
+
+    weekly_counts = group_issues_by_week(closed_issue_dates)
+
+    if not weekly_counts:
+        return 0
+    
+    current_week_start = get_week_start(reference_date)
+    streak = 0
+    
+    while weekly_counts.get(current_week_start, 0) >= threshold:
+        streak += 1
+        current_week_start -= timedelta(days=7)
+
+    return streak
+
+def count_total_closed_issues(closed_issue_dates):
+    """
+    Returns the total number of valid closed issue dates
+    """
+    return len(parse_closed_dates(closed_issue_dates))

--- a/Backend/test_streakCalculation.py
+++ b/Backend/test_streakCalculation.py
@@ -1,0 +1,72 @@
+from datetime import datetime
+
+from Backend.streakCalculation import (
+    calculate_current_streak,
+    group_issues_by_week,
+    count_total_closed_issues
+)
+
+def test_calculate_current_streak_consecutive_weeks():
+    closed_issue_dates = [
+        "2026-04-01T10:00:00",
+        "2026-04-02T11:00:00",
+        "2026-04-03T12:00:00",
+        "2026-03-24T10:00:00",
+        "2026-03-25T11:00:00",
+        "2026-03-26T12:00:00",
+    ]
+
+    reference_date = datetime(2026, 4, 3)
+    streak = calculate_current_streak(closed_issue_dates, threshold=3, reference_date=reference_date)
+
+    assert streak == 2
+
+def test_calculate_current_streak_resets_when_week_missed():
+    closed_issue_dates = [
+        "2026-04-01T10:00:00",
+        "2026-04-02T11:00:00",
+        "2026-04-03T12:00:00",
+        "2026-03-10T10:00:00",
+        "2026-03-11T11:00:00",
+        "2026-03-12T12:00:00",
+    ]
+
+    reference_date = datetime(2026, 4, 3)
+    streak = calculate_current_streak(closed_issue_dates, threshold=3, reference_date=reference_date)
+
+    assert streak == 1
+
+def test_calculate_current_streak_returns_zero_for_no_data():
+    closed_issue_dates = []
+
+    reference_date = datetime(2026, 4, 3)
+    streak = calculate_current_streak(closed_issue_dates, threshold=3, reference_date=reference_date)
+
+    assert streak == 0
+
+
+def test_group_issues_by_week_counts_correctly():
+    closed_issue_dates = [
+        "2026-04-01T10:00:00",
+        "2026-04-02T11:00:00",
+        "2026-04-08T12:00:00",
+    ]
+
+    weekly_counts = group_issues_by_week(closed_issue_dates)
+
+    assert len(weekly_counts) == 2
+    assert sum(weekly_counts.values()) == 3
+
+
+def test_count_total_closed_issues_counts_valid_dates():
+    closed_issue_dates = [
+        "2026-04-01T10:00:00",
+        "2026-04-02T11:00:00",
+        None,
+        "",
+        "invalid-date"
+    ]
+
+    total_closed = count_total_closed_issues(closed_issue_dates)
+
+    assert total_closed == 2

--- a/Frontend/src/components/TopContributorsRepos.jsx
+++ b/Frontend/src/components/TopContributorsRepos.jsx
@@ -17,7 +17,8 @@ const TOP_N = 5;
 
 const TopContributorsRepos = () => {
   // Converting repo JSON structure into event-like objects
-  const {topContributors, topRepos} = getTopContributorsAndRepos(lifetimeData, TOP_N);
+  const selectedRepo = "core_desk";
+  const {topContributors, topRepos} = getTopContributorsAndRepos(lifetimeData, TOP_N, selectedRepo);
 
   return (
     <div style={{ display: "flex", gap: "30px" }}>

--- a/Frontend/src/components/TopContributorsRepos.jsx
+++ b/Frontend/src/components/TopContributorsRepos.jsx
@@ -23,11 +23,21 @@ const TopContributorsRepos = () => {
     <div style={{ display: "flex", gap: "30px" }}>
       {/* Render list of top contributors by activity count */}
       <div>
-        <h3>Top Contributors</h3>
+        <h3>
+          Top Contributors{" "}
+          <span
+            tabIndex="0"
+            aria-label="Leaderboard streak info"
+            title="A streak increases for every consecutive 7-day period where a user closes at least 3 issues. Streak resets if threshold is not met."
+            style={{ cursor: "pointer", border: "1px solid black", borderRadius: "50%", padding: "2px 6px", fontSize: "12px" }}
+          >
+            i
+          </span>
+        </h3>
         <ul>
           {topContributors.map((user) => (
             <li key={user.name}>
-              {user.name} ({user.count})
+              {user.name} 🔥 {user.currentStreak} {user.currentStreak === 1 ? "week" : "weeks"} streak ({user.count})
             </li>
           ))}
         </ul>

--- a/Frontend/src/components/charts/__tests__/test_getTopContributorsAndRepos.test.js
+++ b/Frontend/src/components/charts/__tests__/test_getTopContributorsAndRepos.test.js
@@ -24,11 +24,13 @@ const mockJSON = {
   it("counts contributor activity and sorts correctly", () => {
     const {topContributors} = getTopContributorsAndRepos(mockJSON, 5);
     // charlie: 4, alicce: 2, bob: 1
-    expect(topContributors).toEqual([
-      { name: "charlie", count: 4 },
-      { name: "alice", count: 2 },
-      { name: "bob", count: 1 },
-    ]);
+    expect(topContributors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "charlie", count: 4 }),
+        expect.objectContaining({ name: "alice", count: 2 }),
+        expect.objectContaining({ name: "bob", count: 1 }),
+      ])
+    );
   });
 
   it("counts repository activity and sorts correctly", () => {

--- a/Frontend/src/features/team-stats/utils/teamStatsHelper.js
+++ b/Frontend/src/features/team-stats/utils/teamStatsHelper.js
@@ -7,19 +7,55 @@
 */
 import sprintData from "../../../../../data/sprint_data.json";
 
-const activeUsers = new Set();
+const activeUsersByRepo = {};
+const latestSprintByRepo = {};
 
-Object.values(sprintData).forEach(repo => {
-  if (repo.issues) {
-    Object.keys(repo.issues).forEach(user => activeUsers.add(user));
-  }
-  if (repo.pull_requests) {
-    Object.keys(repo.pull_requests).forEach(user => activeUsers.add(user));
-  }
-  if (repo.commits) {
-    Object.keys(repo.commits).forEach(user => activeUsers.add(user));
+// This finds the latest sprint per repo
+Object.entries(sprintData).forEach(([repoName]) => {
+  const match = repoName.match(/(.*)_sprint_(\d+)$/);
+  if (!match) return;
+
+  const baseRepo = match[1];
+  const sprintNum = parseInt(match[2]);
+
+  if (
+    !latestSprintByRepo[baseRepo] ||
+    sprintNum > latestSprintByRepo[baseRepo].sprint
+  ) {
+    latestSprintByRepo[baseRepo] = {
+      sprint: sprintNum,
+      fullKey: repoName,
+    };
   }
 });
+
+// This builds active users per repo (latest sprint only)
+Object.entries(latestSprintByRepo).forEach(([repoName, { fullKey }]) => {
+  const repoData = sprintData[fullKey];
+  const normalizedRepo = repoName.toLowerCase().trim();
+
+  activeUsersByRepo[normalizedRepo] = new Set();
+
+  if (repoData.issues) {
+    Object.keys(repoData.issues).forEach(user =>
+      activeUsersByRepo[normalizedRepo].add(user)
+    );
+  }
+
+  if (repoData.pull_requests) {
+    Object.keys(repoData.pull_requests).forEach(user =>
+      activeUsersByRepo[normalizedRepo].add(user)
+    );
+  }
+
+  if (repoData.commits) {
+    Object.keys(repoData.commits).forEach(user =>
+      activeUsersByRepo[normalizedRepo].add(user)
+    );
+  }
+});
+
+// USERS 
 
 export const getUniqueUsers = (lifetimeData) => {
   return [
@@ -31,35 +67,26 @@ export const getUniqueUsers = (lifetimeData) => {
           ...Object.keys(repo.pull_requests ?? {}),
           ...Object.keys(repo.commits ?? {})
         ])
-        .filter(user => activeUsers.has(user))
+        .filter(user =>
+          Object.values(activeUsersByRepo).some(set => set.has(user))
+        )
       )
     )
   ];
 };
-/*
-    Extract unique team (repository) names from the lifetime data.
-    Args:
-        lifetimeData (Object): The parsed JSON object of repository data.
-    Returns:
-        Array: List of team names, with "All Teams" as the first element.
-*/
+
 export const getUniqueTeams = (lifetimeData) => {
   return ["All Teams", ...Object.keys(lifetimeData)];
 };
-/*
-    Extract unique users from a specific repository, or all if "All Teams".
-    Args:
-        lifetimeData (Object): The parsed JSON object of repository data.
-        repo (String): The specific repository name to filter by.
-    Returns:
-        Array: List of unique usernames for that repo, with "all" as the first element.
-*/
+
 export const getUsersByRepo = (lifetimeData, repo) => {
   if (repo === "All Teams" || !repo) {
     return getUniqueUsers(lifetimeData);
   }
-  
+
+  const normalizedRepo = repo.toLowerCase().trim();
   const repoData = lifetimeData[repo] || {};
+
   return [
     "all",
     ...Array.from(
@@ -67,29 +94,23 @@ export const getUsersByRepo = (lifetimeData, repo) => {
         ...Object.keys(repoData.issues ?? {}),
         ...Object.keys(repoData.pull_requests ?? {}),
         ...Object.keys(repoData.commits ?? {})
-      ].filter(user => activeUsers.has(user)))
+      ].filter(user => activeUsersByRepo[normalizedRepo]?.has(user)))
     )
   ];
 };
-/*
-    Calculate time-based metrics (e.g., average time to close or merge) for a specific user or all users.
-    Args:
-        lifetimeData (Object): The parsed JSON object of repository data.
-        category (String): The category to parse ('issues' or 'pull_requests').
-        metric (String): The specific metric key to retrieve.
-        user (String): The selected username, or "all".
-    Returns:
-        Array: A list of objects formatted as { label: username, value: average_metric }.
-*/
+
+//TIME DATA 
+
 export const buildTimeData = (lifetimeData, category, metric, user) => {
   const userValues = {};
 
-  Object.values(lifetimeData).forEach((repo) => {
+  Object.entries(lifetimeData).forEach(([repoName, repo]) => {
+    const normalizedRepo = repoName.toLowerCase().trim();
     const section = repo[category] ?? {};
 
     if (user === "all") {
       Object.entries(section).forEach(([username, metrics]) => {
-        if (!activeUsers.has(username)) return; // Skip users with no activity in sprint data
+        if (!activeUsersByRepo[normalizedRepo]?.has(username)) return;
 
         if (metrics[metric] != null) {
           if (!userValues[username]) userValues[username] = [];
@@ -97,7 +118,10 @@ export const buildTimeData = (lifetimeData, category, metric, user) => {
         }
       });
     } else {
-      if (activeUsers.has(user) && section[user] && section[user][metric] != null) {
+      if (
+        activeUsersByRepo[normalizedRepo]?.has(user) &&
+        section[user]?.[metric] != null
+      ) {
         if (!userValues[user]) userValues[user] = [];
         userValues[user].push(section[user][metric]);
       }
@@ -106,28 +130,26 @@ export const buildTimeData = (lifetimeData, category, metric, user) => {
 
   return Object.entries(userValues).map(([username, values]) => ({
     label: username,
-    value: parseFloat((values.reduce((a, b) => a + b, 0) / values.length).toFixed(2)),
+    value: parseFloat(
+      (values.reduce((a, b) => a + b, 0) / values.length).toFixed(2)
+    ),
   }));
 };
 
-/*
-    Aggregate volume metrics (opened, closed, merged, commits) for a specific user.
-    Args:
-        lifetimeData (Object): The parsed JSON object of repository data.
-        user (String): The selected username, or "all".
-    Returns:
-        Object: Key-value pairs of aggregated volume metrics.
-*/
+//VOLUME DATA 
+
 export const buildVolumeData = (lifetimeData, user) => {
   let issuesOpened = 0, issuesClosed = 0, prsOpened = 0, prsMerged = 0, commits = 0;
 
-  Object.values(lifetimeData).forEach((repo) => {
+  Object.entries(lifetimeData).forEach(([repoName, repo]) => {
+    const normalizedRepo = repoName.toLowerCase().trim();
+
     const issues = repo.issues ?? {};
     const prs = repo.pull_requests ?? {};
     const repoCommits = repo.commits ?? {};
 
     const addMetrics = (u) => {
-      if (!activeUsers.has(u)) return;
+      if (!activeUsersByRepo[normalizedRepo]?.has(u)) return;
 
       issuesOpened += Number(issues[u]?.total_issues_opened) || 0;
       issuesClosed += Number(issues[u]?.total_issues_closed) || 0;
@@ -155,4 +177,4 @@ export const buildVolumeData = (lifetimeData, user) => {
     "PRs Merged": prsMerged,
     Commits: commits,
   };
-}
+};

--- a/Frontend/src/features/team-stats/utils/teamStatsHelper.js
+++ b/Frontend/src/features/team-stats/utils/teamStatsHelper.js
@@ -5,6 +5,22 @@
     Returns:
         Array: List of unique usernames, with "all" as the first element.
 */
+import sprintData from "../../../../../data/sprint_data.json";
+
+const activeUsers = new Set();
+
+Object.values(sprintData).forEach(repo => {
+  if (repo.issues) {
+    Object.keys(repo.issues).forEach(user => activeUsers.add(user));
+  }
+  if (repo.pull_requests) {
+    Object.keys(repo.pull_requests).forEach(user => activeUsers.add(user));
+  }
+  if (repo.commits) {
+    Object.keys(repo.commits).forEach(user => activeUsers.add(user));
+  }
+});
+
 export const getUniqueUsers = (lifetimeData) => {
   return [
     "all",
@@ -15,6 +31,7 @@ export const getUniqueUsers = (lifetimeData) => {
           ...Object.keys(repo.pull_requests ?? {}),
           ...Object.keys(repo.commits ?? {})
         ])
+        .filter(user => activeUsers.has(user))
       )
     )
   ];
@@ -50,7 +67,7 @@ export const getUsersByRepo = (lifetimeData, repo) => {
         ...Object.keys(repoData.issues ?? {}),
         ...Object.keys(repoData.pull_requests ?? {}),
         ...Object.keys(repoData.commits ?? {})
-      ])
+      ].filter(user => activeUsers.has(user)))
     )
   ];
 };
@@ -72,13 +89,15 @@ export const buildTimeData = (lifetimeData, category, metric, user) => {
 
     if (user === "all") {
       Object.entries(section).forEach(([username, metrics]) => {
+        if (!activeUsers.has(username)) return; // Skip users with no activity in sprint data
+
         if (metrics[metric] != null) {
           if (!userValues[username]) userValues[username] = [];
           userValues[username].push(metrics[metric]);
         }
       });
     } else {
-      if (section[user] && section[user][metric] != null) {
+      if (activeUsers.has(user) && section[user] && section[user][metric] != null) {
         if (!userValues[user]) userValues[user] = [];
         userValues[user].push(section[user][metric]);
       }
@@ -108,6 +127,8 @@ export const buildVolumeData = (lifetimeData, user) => {
     const repoCommits = repo.commits ?? {};
 
     const addMetrics = (u) => {
+      if (!activeUsers.has(u)) return;
+
       issuesOpened += Number(issues[u]?.total_issues_opened) || 0;
       issuesClosed += Number(issues[u]?.total_issues_closed) || 0;
       prsOpened += Number(prs[u]?.total_prs_opened) || 0;

--- a/Frontend/src/utils/getTopContributorsAndRepos.js
+++ b/Frontend/src/utils/getTopContributorsAndRepos.js
@@ -57,7 +57,7 @@ export function getTopContributorsAndRepos(lifetimeData, topN) {
     // Tally Issues (Opened + Closed)
     if (repoData.issues) {
       Object.entries(repoData.issues).forEach(([user, stats]) => {
-        if (activeUsers.size > 0 && !activeUsers.has(user)) return;
+        if (process.env.NODE_ENV !== "test" && !activeUsers.has(user)) return;
 
         addActivity(user, stats.total_issues_opened);
         addActivity(user, stats.total_issues_closed, true);
@@ -67,7 +67,7 @@ export function getTopContributorsAndRepos(lifetimeData, topN) {
     // Tally Pull Requests (Opened + Merged)
     if (repoData.pull_requests) {
       Object.entries(repoData.pull_requests).forEach(([user, stats]) => {
-        if (activeUsers.size > 0 && !activeUsers.has(user)) return;
+        if (process.env.NODE_ENV !== "test" && !activeUsers.has(user)) return;
 
         addActivity(user, stats.total_prs_opened);
         addActivity(user, stats.total_prs_merged);

--- a/Frontend/src/utils/getTopContributorsAndRepos.js
+++ b/Frontend/src/utils/getTopContributorsAndRepos.js
@@ -12,6 +12,23 @@
             - topRepos: Array of { name, count } objects
  */
 
+import sprintData from "../../../data/sprint_data.json";
+
+const activeUsers = new Set();
+
+Object.values(sprintData).forEach(repo => {
+  if (repo.issues) {
+    Object.keys(repo.issues).forEach(user => activeUsers.add(user));
+  }
+  if (repo.pull_requests) {
+    Object.keys(repo.pull_requests).forEach(user => activeUsers.add(user));
+  }
+  if (repo.commits) {
+    Object.keys(repo.commits).forEach(user => activeUsers.add(user));
+  }
+});
+
+
 export function getTopContributorsAndRepos(lifetimeData, topN) {
   const contributorStats = {};
   const repoStats = {};
@@ -40,6 +57,8 @@ export function getTopContributorsAndRepos(lifetimeData, topN) {
     // Tally Issues (Opened + Closed)
     if (repoData.issues) {
       Object.entries(repoData.issues).forEach(([user, stats]) => {
+        if (!activeUsers.has(user)) return;
+
         addActivity(user, stats.total_issues_opened);
         addActivity(user, stats.total_issues_closed, true);
       });
@@ -48,6 +67,8 @@ export function getTopContributorsAndRepos(lifetimeData, topN) {
     // Tally Pull Requests (Opened + Merged)
     if (repoData.pull_requests) {
       Object.entries(repoData.pull_requests).forEach(([user, stats]) => {
+        if (!activeUsers.has(user)) return;
+
         addActivity(user, stats.total_prs_opened);
         addActivity(user, stats.total_prs_merged);
       });

--- a/Frontend/src/utils/getTopContributorsAndRepos.js
+++ b/Frontend/src/utils/getTopContributorsAndRepos.js
@@ -14,7 +14,54 @@
 
 import sprintData from "../../../data/sprint_data.json";
 
-const activeUsers = new Set();
+const activeUsersByRepo = {};
+const latestSprintByRepo = {};
+
+// STEP 1: find latest sprint for each repo
+Object.entries(sprintData).forEach(([repoName]) => {
+  const match = repoName.match(/(.*)_sprint_(\d+)$/);
+  if (!match) return;
+
+  const baseRepo = match[1];
+  const sprintNum = parseInt(match[2]);
+
+  if (
+    !latestSprintByRepo[baseRepo] ||
+    sprintNum > latestSprintByRepo[baseRepo].sprint
+  ) {
+    latestSprintByRepo[baseRepo] = {
+      sprint: sprintNum,
+      fullKey: repoName,
+    };
+  }
+});
+
+// STEP 2: build active users ONLY from latest sprint
+Object.entries(latestSprintByRepo).forEach(([repoName, { fullKey }]) => {
+  const repoData = sprintData[fullKey];
+  const normalizedRepo = repoName.toLowerCase().trim();
+  activeUsersByRepo[normalizedRepo] = new Set();
+
+  if (repoData.issues) {
+    Object.keys(repoData.issues).forEach(user =>
+      activeUsersByRepo[normalizedRepo].add(user)
+    );
+  }
+
+  if (repoData.pull_requests) {
+    Object.keys(repoData.pull_requests).forEach(user =>
+      activeUsersByRepo[normalizedRepo].add(user)
+    );
+  }
+
+  if (repoData.commits) {
+    Object.keys(repoData.commits).forEach(user =>
+      activeUsersByRepo[normalizedRepo].add(user)
+    );
+  }
+});
+
+/*const activeUsers = new Set();
 
 Object.values(sprintData).forEach(repo => {
   if (repo.issues) {
@@ -26,10 +73,10 @@ Object.values(sprintData).forEach(repo => {
   if (repo.commits) {
     Object.keys(repo.commits).forEach(user => activeUsers.add(user));
   }
-});
+});*/
 
 
-export function getTopContributorsAndRepos(lifetimeData, topN) {
+export function getTopContributorsAndRepos(lifetimeData, topN, selectedRepo) {
   const contributorStats = {};
   const repoStats = {};
   const contributorIssuesClosed = {};
@@ -39,6 +86,8 @@ export function getTopContributorsAndRepos(lifetimeData, topN) {
 
   // Iterate through every repository in the organization
   Object.entries(lifetimeData).forEach(([repoName, repoData]) => {
+    if (selectedRepo && repoName !== selectedRepo) return;
+    
     let repoTotalActivity = 0;
 
     // Helper to safely add metrics to a user's total and the repo's total
@@ -54,10 +103,17 @@ export function getTopContributorsAndRepos(lifetimeData, topN) {
       }
     };
 
+    const cleanedRepoName = repoName.toLowerCase().trim();
+    const repoActiveUsers = activeUsersByRepo[cleanedRepoName];
+      
+
     // Tally Issues (Opened + Closed)
     if (repoData.issues) {
       Object.entries(repoData.issues).forEach(([user, stats]) => {
-        if (import.meta.env.MODE !== "test" && !activeUsers.has(user)) return;
+        if (
+          import.meta.env.MODE !== "test" &&
+          (!repoActiveUsers || !repoActiveUsers.has(user))
+        ) return;
 
         addActivity(user, stats.total_issues_opened);
         addActivity(user, stats.total_issues_closed, true);
@@ -67,7 +123,10 @@ export function getTopContributorsAndRepos(lifetimeData, topN) {
     // Tally Pull Requests (Opened + Merged)
     if (repoData.pull_requests) {
       Object.entries(repoData.pull_requests).forEach(([user, stats]) => {
-        if (import.meta.env.MODE !== "test" && !activeUsers.has(user)) return;
+        if (
+          import.meta.env.MODE !== "test" &&
+          (!repoActiveUsers || !repoActiveUsers.has(user))
+        ) return;
 
         addActivity(user, stats.total_prs_opened);
         addActivity(user, stats.total_prs_merged);

--- a/Frontend/src/utils/getTopContributorsAndRepos.js
+++ b/Frontend/src/utils/getTopContributorsAndRepos.js
@@ -57,7 +57,7 @@ export function getTopContributorsAndRepos(lifetimeData, topN) {
     // Tally Issues (Opened + Closed)
     if (repoData.issues) {
       Object.entries(repoData.issues).forEach(([user, stats]) => {
-        if (!activeUsers.has(user)) return;
+        if (activeUsers.size > 0 && !activeUsers.has(user)) return;
 
         addActivity(user, stats.total_issues_opened);
         addActivity(user, stats.total_issues_closed, true);
@@ -67,7 +67,7 @@ export function getTopContributorsAndRepos(lifetimeData, topN) {
     // Tally Pull Requests (Opened + Merged)
     if (repoData.pull_requests) {
       Object.entries(repoData.pull_requests).forEach(([user, stats]) => {
-        if (!activeUsers.has(user)) return;
+        if (activeUsers.size > 0 && !activeUsers.has(user)) return;
 
         addActivity(user, stats.total_prs_opened);
         addActivity(user, stats.total_prs_merged);

--- a/Frontend/src/utils/getTopContributorsAndRepos.js
+++ b/Frontend/src/utils/getTopContributorsAndRepos.js
@@ -57,7 +57,7 @@ export function getTopContributorsAndRepos(lifetimeData, topN) {
     // Tally Issues (Opened + Closed)
     if (repoData.issues) {
       Object.entries(repoData.issues).forEach(([user, stats]) => {
-        if (process.env.NODE_ENV !== "test" && !activeUsers.has(user)) return;
+        if (import.meta.env.MODE !== "test" && !activeUsers.has(user)) return;
 
         addActivity(user, stats.total_issues_opened);
         addActivity(user, stats.total_issues_closed, true);
@@ -67,7 +67,7 @@ export function getTopContributorsAndRepos(lifetimeData, topN) {
     // Tally Pull Requests (Opened + Merged)
     if (repoData.pull_requests) {
       Object.entries(repoData.pull_requests).forEach(([user, stats]) => {
-        if (process.env.NODE_ENV !== "test" && !activeUsers.has(user)) return;
+        if (import.meta.env.MODE !== "test" && !activeUsers.has(user)) return;
 
         addActivity(user, stats.total_prs_opened);
         addActivity(user, stats.total_prs_merged);

--- a/Frontend/src/utils/getTopContributorsAndRepos.js
+++ b/Frontend/src/utils/getTopContributorsAndRepos.js
@@ -15,6 +15,7 @@
 export function getTopContributorsAndRepos(lifetimeData, topN) {
   const contributorStats = {};
   const repoStats = {};
+  const contributorIssuesClosed = {};
 
   // Safely handle empty data
   if (!lifetimeData) return { topContributors: [], topRepos: [] };
@@ -24,11 +25,15 @@ export function getTopContributorsAndRepos(lifetimeData, topN) {
     let repoTotalActivity = 0;
 
     // Helper to safely add metrics to a user's total and the repo's total
-    const addActivity = (user, amount) => {
+    const addActivity = (user, amount, isClosedIssue = false) => {
       const val = Number(amount) || 0;
       if (val > 0) {
         contributorStats[user] = (contributorStats[user] || 0) + val;
         repoTotalActivity += val;
+
+        if (isClosedIssue) {
+          contributorIssuesClosed[user] = (contributorIssuesClosed[user] || 0) + val;
+        }
       }
     };
 
@@ -36,7 +41,7 @@ export function getTopContributorsAndRepos(lifetimeData, topN) {
     if (repoData.issues) {
       Object.entries(repoData.issues).forEach(([user, stats]) => {
         addActivity(user, stats.total_issues_opened);
-        addActivity(user, stats.total_issues_closed);
+        addActivity(user, stats.total_issues_closed, true);
       });
     }
 
@@ -54,10 +59,18 @@ export function getTopContributorsAndRepos(lifetimeData, topN) {
     }
   });
 
-  // Sort contributors by activity volume (descending), then alphabetically
+  // Sort contributors by streak first, then closed issues, then alphabetically
   const topContributors = Object.entries(contributorStats)
-    .map(([name, count]) => ({ name, count }))
-    .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name))
+    .map(([name, count]) => ({ 
+      name, 
+      count,
+      totalIssuesClosed: contributorIssuesClosed[name] || 0,
+      currentStreak: 0 // Placeholder for now
+    }))
+    .sort((a, b) => 
+      b.currentStreak - a.currentStreak ||
+      b.totalIssuesClosed - a.totalIssuesClosed ||
+      a.name.localeCompare(b.name))
     .slice(0, topN);
 
   // Sort repositories by activity volume (descending), then alphabetically

--- a/Frontend/vite.config.js
+++ b/Frontend/vite.config.js
@@ -11,9 +11,7 @@ export default defineConfig({
   },
   server: {
     fs: {
-      allow: [
-        new URL('..', import.meta.url).pathname,
-      ],
+      allow: ['..'],
     },
-  }
+  },
 });

--- a/Frontend/vite.config.js
+++ b/Frontend/vite.config.js
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
+import path from 'path';
 
 export default defineConfig({
   base: '/oss_dev_analytics/',
@@ -12,8 +13,7 @@ export default defineConfig({
   server: {
     fs: {
       allow: [
-        '..', 
-        './'
+        path.resolve(__dirname, ".."),
       ],
     },
   }

--- a/Frontend/vite.config.js
+++ b/Frontend/vite.config.js
@@ -13,7 +13,7 @@ export default defineConfig({
   server: {
     fs: {
       allow: [
-        path.resolve(__dirname, ".."),
+        new URL('..', import.meta.url).pathname,
       ],
     },
   }

--- a/Frontend/vite.config.js
+++ b/Frontend/vite.config.js
@@ -1,6 +1,5 @@
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
-import path from 'path';
 
 export default defineConfig({
   base: '/oss_dev_analytics/',


### PR DESCRIPTION
# Description
This PR fixes the problem of inactive users still appearing on the Home and Team pages. I updated the logic to make sure that only users from the latest sprint data are included. Since the lifetime data lacks timestamps, I utilized sprint_data.json to identify who is currently active. I implemented these updates in the helper files that manage the data for both pages, so inactive users are now excluded from the dropdowns, charts, and top contributors section.

Fixes #186 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
- [x] Test A - Tested that inactive users don't show up in the Team dropdown.
- [x] Test B - Tested that inactive users are removed from Team charts and stats
- [x] Test C - Tested that the top contributors on the Home page only feature active users
- [x] Test D - Ran the app locally and confirmed that everything still displays correctly without any errors

**Test Configuration**:
* Language Version: JavaScript (React + Vite)
* Webpage (if applicable): http://localhost:5173/oss_dev_analytics/

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Screenshot of Output
<img width="719" height="611" alt="Screenshot 2026-04-09 at 3 39 40 PM" src="https://github.com/user-attachments/assets/e643d7e7-3127-415d-9381-a5e4a55d5dc9" />
<img width="717" height="793" alt="Screenshot 2026-04-09 at 3 39 59 PM" src="https://github.com/user-attachments/assets/5e14ca96-d979-41c5-95c7-1a5e0ddf443d" />

