### PR TITLE
Gitauthen with updated user github pfp and username displayed

### DIFF
--- a/Frontend/src/components/NavBar.jsx
+++ b/Frontend/src/components/NavBar.jsx
@@ -15,6 +15,15 @@ export const Navbar = () => {
     return () => unsubscribe(); 
   }, []);
 
+  const githubData = user?.providerData?.[0];
+// to collect and return their github username and picture
+  const displayName =
+    githubData?.displayName ||
+    user?.reloadUserInfo?.screenName ||
+    "GitHub User";
+
+  const photoURL = githubData?.photoURL || loginProfile;
+
   return (
     <div style={styles.wrapper}>
       <nav style={styles.nav}>
@@ -41,14 +50,17 @@ export const Navbar = () => {
               Team
             </Link>
           </li>
-
+        
           <li style={{ textAlign: "center" }}>
-            <Link to="/login" style={styles.link}>
-              <img src={loginProfile} alt="Profile" style={styles.profileImg} />
+            <Link to={user ? "/" : "/login"} style={styles.link}> 
+              <img src={photoURL} alt="Profile" style={styles.profileImg} />
             </Link>
 
-            {/* text to say signed in */}
-            {user && <div style={styles.signedInText}>Signed in!</div>}
+            {user && (
+              <div style={styles.userInfo}>
+                <div style={styles.username}>{displayName}</div>
+              </div>
+            )}
           </li>
         </ul>
       </nav>
@@ -107,11 +119,20 @@ const styles = {
     height: "40px",
     objectFit: "cover",
     cursor: "pointer",
+    borderRadius: "50%",
   },
   signedInText: {
     fontSize: "12px",
     marginTop: "5px",
     color: "#A8D0FF",
+  },
+  username: {
+    fontSize: "12px",
+    color: "#A8D0FF",
+    maxWidth: "80px",
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
   },
 };
 


### PR DESCRIPTION
# Description

Added updated profile picture and github username. Collects the user's Github user uder displayName and picture under photoURL. This provides the user with a more customized expirience 

Fixes # 172

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Went under an incognito tab to check that there is no profile picture or username when not signed in, then once logged in it updated with your github profile picture and display name. I also tested this by changing my github profile picture and making sure it updates on the website. 

- [ ] Test A
- [ ] Test B

**Test Configuration**: npm run dev
* Language Version: jsx
* Webpage (if applicable): npm run dev

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

# Screenshot of Output
Please provide a screenshot of your output below (during all tests if applicable)
<img width="3006" height="1188" alt="image" src="https://github.com/user-attachments/assets/b968545e-9e75-499d-86d8-d933397793dd" />

