### PR TITLE
Contributor Impact Bubble chart on Home and Team

### DIFF
--- a/Frontend/src/components/charts/ContributorImpactChart.jsx
+++ b/Frontend/src/components/charts/ContributorImpactChart.jsx
@@ -1,0 +1,88 @@
+import React from "react";
+
+import {
+  ScatterChart,
+  Scatter,
+  XAxis,
+  YAxis,
+  ZAxis,
+  Tooltip,
+  ResponsiveContainer,
+  CartesianGrid,
+} from "recharts";
+
+export const ContributorImpactChart = ({ data }) => {
+
+  return (
+    <div className="bg-[#F5F7FB] rounded-xl p-5 shadow-sm w-full">
+      <h3 className="text-[#1F3A68] font-semibold text-md mb-4">
+        Contributor Impact Map
+      </h3>
+
+      {/* Chart Container */}
+      <div className="bg-white rounded-lg p-4">
+        <ResponsiveContainer width="100%" height={320}>
+          <ScatterChart>
+            <CartesianGrid stroke="#E5E7EB" />
+
+            <XAxis
+              type="number"
+              dataKey="commits"
+              name="Commits"
+              tick={{ fill: "#6B7280", fontSize: 12 }}
+              label={{
+                value: "Commits (Experience)",
+                position: "insideBottom",
+                offset: -5,
+                fill: "#6B7280",
+                fontSize: 12,
+              }}
+            />
+
+            <YAxis
+              type="number"
+              dataKey="issuesClosed"
+              name="Issues Closed"
+              tick={{ fill: "#6B7280", fontSize: 12 }}
+              label={{
+                value: "Issues Closed",
+                angle: -90,
+                position: "insideLeft",
+                fill: "#6B7280",
+                fontSize: 12,
+              }}
+            />
+
+            <ZAxis
+              type="number"
+              dataKey="prsOpened"
+              range={[40, 300]}
+              name="PRs Opened"
+            />
+
+            <Tooltip
+              contentStyle={{
+                backgroundColor: "#fff",
+                border: "1px solid #E5E7EB",
+                borderRadius: "8px",
+                fontSize: "12px",
+              }}
+              formatter={(value, name) => [value, name]}
+              labelFormatter={(label, payload) =>
+                payload?.[0]?.payload?.name || ""
+              }
+            />
+
+            <Scatter data={data} fill="#3B82F6" />
+          </ScatterChart>
+        </ResponsiveContainer>
+      </div>
+
+      <div className="mt-3 text-xs text-gray-500">
+        Each bubble represents a contributor. Larger bubbles indicate more pull
+        requests opened, while position reflects experience (commits) and impact
+        (issues closed).
+      </div>
+    </div>
+  );
+};

--- a/Frontend/src/features/home/routes/Home.jsx
+++ b/Frontend/src/features/home/routes/Home.jsx
@@ -1,9 +1,11 @@
 import { useState } from "react";
-import VolumeCharts from "../../../components/charts/VolumeBased";
-import { transformVolumeData } from "../../../utils/TransformVolumeData";
 import CollaborationChart from "../../../components/charts/CollaborationChart";
 import { getTopContributorsAndRepos } from "../../../utils/getTopContributorsAndRepos";
 import lifetimeData from "../../../../../data/lifetime_data.json";
+import sprintData from "../../../../../data/sprint_data.json";
+import { buildBubbleData } from "../../../utils/transformContributorData";
+import { ContributorImpactChart } from "../../../components/charts/ContributorImpactChart";
+
 import "./Home.css";
 
 /*
@@ -12,9 +14,7 @@ import "./Home.css";
         JSX.Element: The Home dashboard component.
 */
 export const Home = () => {
-  const [repoLimit, setRepoLimit] = useState(5);
-  const orgVolumeData = transformVolumeData(lifetimeData, 'org', null, "All");
-  
+  const [repoLimit, setRepoLimit] = useState(5);  
   const collaborationData = Object.entries(lifetimeData)
   .map(([repoName, repo]) => {
     const totalIssuesClosed = Object.values(repo.issues || {}).reduce(
@@ -48,18 +48,20 @@ export const Home = () => {
   .sort((a, b) => b.collaborationScore - a.collaborationScore)
   .slice(0, repoLimit);
 
+
   // 2. Call your utility function right here to get the top 5
   const { topContributors, topRepos } = getTopContributorsAndRepos(lifetimeData, 12, null);
-
+  const contributorImpactData = buildBubbleData(sprintData);
+  
   return (
     <div className="home-container">
-      
       <header className="home-header">
         <h1 className="home-title">OSS Analytics Dashboard</h1>
       </header>
       <div className="home-grid">
-          <section className="card-blue">
-          <h2 className="card-title">Collaboration Index
+        <section className="card-blue">
+          <h2 className="card-title">
+            Collaboration Index
             <span
               tabIndex="0"
               aria-label="Collaboration chart info"
@@ -70,12 +72,11 @@ export const Home = () => {
                 borderRadius: "50%",
                 padding: "2px 6px",
                 fontSize: "12px",
-                fontWeight: "normal"
+                fontWeight: "normal",
               }}
             >
-               i
+              i
             </span>
-
           </h2>
 
           <div className="chart-wrapper">
@@ -84,31 +85,41 @@ export const Home = () => {
                 Show top repos:
               </label>
               <select
-              value={repoLimit}
-        onChange={(e) => setRepoLimit(Number(e.target.value))}
-        style={{
-          padding: "6px 10px",
-          borderRadius: "8px",
-          border: "1px solid #ccc",
-        }}
-      >
-        <option value={3}>3</option>
-        <option value={5}>5</option>
-        <option value={7}>7</option>
-        <option value={10}>10</option>
-      </select>
-    </div>
+                value={repoLimit}
+                onChange={(e) => setRepoLimit(Number(e.target.value))}
+                style={{
+                  padding: "6px 10px",
+                  borderRadius: "8px",
+                  border: "1px solid #ccc",
+                }}
+              >
+                <option value={3}>3</option>
+                <option value={5}>5</option>
+                <option value={7}>7</option>
+                <option value={10}>10</option>
+              </select>
+            </div>
 
-    <CollaborationChart data={collaborationData} />
-  </div>
-    </section>
+            <CollaborationChart data={collaborationData} />
+          </div>
+        </section>
         <section className="card-blue" style={{ height: "100%" }}>
           <h2 className="card-title">Leaderboard Streaks</h2>
-          <div className="contributors-wrapper" style={{ display: "flex", gap: "40px", marginTop: "8px" }}>
-            
+          <div
+            className="contributors-wrapper"
+            style={{ display: "flex", gap: "40px", marginTop: "8px" }}
+          >
             {/* Top Contributors List */}
             <div style={{ flex: 1 }}>
-              <h3 style={{ fontSize: "16px", fontWeight: "bold", color: "#123f8b", marginBottom: "12px", marginTop: 0 }}>
+              <h3
+                style={{
+                  fontSize: "16px",
+                  fontWeight: "bold",
+                  color: "#123f8b",
+                  marginBottom: "12px",
+                  marginTop: 0,
+                }}
+              >
                 Top Contributors{" "}
                 <span
                   tabIndex="0"
@@ -119,7 +130,7 @@ export const Home = () => {
                     border: "1px solid black",
                     borderRadius: "50%",
                     padding: "2px 6px",
-                    fontSize: "12px"
+                    fontSize: "12px",
                   }}
                 >
                   i
@@ -129,7 +140,8 @@ export const Home = () => {
                 {topContributors.length > 0 ? (
                   topContributors.map((user, index) => (
                     <li key={`user-${index}`} style={{ marginBottom: "4px" }}>
-                      {user.name} 🔥 {user.currentStreak} {user.currentStreak === 1 ? "week" : "weeks"} streak
+                      {user.name} 🔥 {user.currentStreak}{" "}
+                      {user.currentStreak === 1 ? "week" : "weeks"} streak
                     </li>
                   ))
                 ) : (
@@ -140,7 +152,15 @@ export const Home = () => {
 
             {/* Top Repositories List */}
             <div style={{ flex: 1 }}>
-              <h3 style={{ fontSize: "16px", fontWeight: "bold", color: "#123f8b", marginBottom: "12px", marginTop: 0 }}>
+              <h3
+                style={{
+                  fontSize: "16px",
+                  fontWeight: "bold",
+                  color: "#123f8b",
+                  marginBottom: "12px",
+                  marginTop: 0,
+                }}
+              >
                 Top Repositories{" "}
                 <span
                   tabIndex="0"
@@ -151,7 +171,7 @@ export const Home = () => {
                     border: "1px solid black",
                     borderRadius: "50%",
                     padding: "2px 6px",
-                    fontSize: "12px"
+                    fontSize: "12px",
                   }}
                 >
                   i
@@ -161,7 +181,10 @@ export const Home = () => {
                 {topRepos && topRepos.length > 0 ? (
                   topRepos.map((repo, index) => (
                     <li key={`repo-${index}`} style={{ marginBottom: "4px" }}>
-                      {repo.name} 🔥 {repo.streak} {repo.streak === 1 ? "week" : "weeks"} streak ({repo.activeMembers} {repo.activeMembers === 1 ? "member" : "members"})
+                      {repo.name} 🔥 {repo.streak}{" "}
+                      {repo.streak === 1 ? "week" : "weeks"} streak (
+                      {repo.activeMembers}{" "}
+                      {repo.activeMembers === 1 ? "member" : "members"})
                     </li>
                   ))
                 ) : (
@@ -169,35 +192,68 @@ export const Home = () => {
                 )}
               </ul>
             </div>
-
           </div>
         </section>
       </div>
+
       <div className="home-grid">
         <div className="handbook-column">
-          <a href="https://docs.google.com/forms/d/e/1FAIpQLSdZF2zfa72ei0rg52cEIh0vpFiOKDmf27oF1DF2E3Oaf1Jhzg/viewform" target="_blank" rel="noreferrer" className="handbook-card">
+          <a
+            href="https://docs.google.com/forms/d/e/1FAIpQLSdZF2zfa72ei0rg52cEIh0vpFiOKDmf27oF1DF2E3Oaf1Jhzg/viewform"
+            target="_blank"
+            rel="noreferrer"
+            className="handbook-card"
+          >
             <div className="handbook-icon">📄</div>
             <div className="handbook-text">FEEDBACK FORM</div>
           </a>
 
-          <a href="https://github.com/oss-slu/handbook_developer" target="_blank" rel="noreferrer" className="handbook-card">
+          <a
+            href="https://github.com/oss-slu/handbook_developer"
+            target="_blank"
+            rel="noreferrer"
+            className="handbook-card"
+          >
             <div className="handbook-icon">📄</div>
             <div className="handbook-text">DEVELOPER HANDBOOK</div>
           </a>
 
-          <a href="https://github.com/oss-slu/handbook_tech_lead" target="_blank" rel="noreferrer" className="handbook-card">
+          <a
+            href="https://github.com/oss-slu/handbook_tech_lead"
+            target="_blank"
+            rel="noreferrer"
+            className="handbook-card"
+          >
             <div className="handbook-icon">📄</div>
             <div className="handbook-text">TECH LEAD HANDBOOK</div>
           </a>
         </div>
+
+        {/* contributor impact bubble chart  */}
         <section className="card-blue">
-          <h2 className="card-title">Organization Volume</h2>
+          <h2 className="card-title">
+            Contributor Impact Map
+            <span
+              tabIndex="0"
+              title="Shows contributor impact using commits (experience), issues closed (impact), and PR activity."
+              style={{
+                cursor: "pointer",
+                border: "1px solid black",
+                borderRadius: "50%",
+                padding: "2px 6px",
+                fontSize: "12px",
+                marginLeft: "6px",
+              }}
+            >
+              i
+            </span>
+          </h2>
+
           <div className="chart-wrapper">
-            <VolumeCharts data={orgVolumeData} repos="All" />
+            <ContributorImpactChart data={contributorImpactData} />
           </div>
         </section>
       </div>
     </div>
-
   );
 };

--- a/Frontend/src/features/team-stats/routes/TeamStats.jsx
+++ b/Frontend/src/features/team-stats/routes/TeamStats.jsx
@@ -1,6 +1,5 @@
 import { useState, useMemo, useEffect } from "react";
 import TimeBased from "../../../components/charts/TimeBased";
-import VolumeCharts from "../../../components/charts/VolumeBased";
 import PRMergeSuccessRateChart from "../../../components/charts/PRMergeSuccessRateChart";
 import lifetime from "../../../../../data/lifetime_data.json";
 import sprint from "../../../../../data/sprint_data.json";
@@ -29,6 +28,9 @@ import {
   fetchAvailableRepos,
   fetchOrCreateUserDocument,
 } from "../utils/teamStatsAccounts.js";
+
+import { buildBubbleData } from "../../../utils/transformContributorData";
+import { ContributorImpactChart } from "../../../components/charts/ContributorImpactChart";
 
 /*
 Constants
@@ -88,6 +90,10 @@ export const TeamStats = () => {
   const volumeData = useMemo(
     () => buildVolumeData(effectiveData, effectiveUser),
     [effectiveData, effectiveUser]
+  );
+  const contributorImpactData = useMemo(
+    () => buildBubbleData(effectiveData),
+    [effectiveData]
   );
 
   // Auth and User Doc Effects
@@ -229,87 +235,72 @@ export const TeamStats = () => {
         />
         <h2 className="section-heading">PR Metrics</h2>
         <div className="chart-card">
-          <PRMergeSuccessRateChart 
+          <PRMergeSuccessRateChart
             selectedTeam={view === "team" ? selectedTeam : selectedUserRepo}
           />
           <p className="chart-sublabel">
             PR Merge Success Rate (Lifetime vs Sprint)
-            </p>
-           </div>
+          </p>
+        </div>
 
         {selectedRepo !== "All Teams" && teamRadarData.length > 0 && (
           <>
             <h2 className="section-heading">Collaboration Metrics</h2>
             <div className="chart-card">
-              <CollaborationChart data={teamRadarData} mode = "team"/>
+              <CollaborationChart data={teamRadarData} mode="team" />
             </div>
-
           </>
-        )}    
+        )}
         <h2 className="section-heading">Time-Based Metrics</h2>
-          <div className="chart-card">
-            <TimeBased
-              data={mergeData}
-              xKey="label"
-              yKey="value"
-              title="Avg Time to Merge PRs (hrs)"
-              repos={view === "team" ? selectedTeam : selectedUserRepo}
-              user={
-                view === "user" && selectedUser !== "all"
-                  ? selectedUser
-                  : null
-              }
-            />
-          </div>
+        <div className="chart-card">
+          <TimeBased
+            data={mergeData}
+            xKey="label"
+            yKey="value"
+            title="Avg Time to Merge PRs (hrs)"
+            repos={view === "team" ? selectedTeam : selectedUserRepo}
+            user={
+              view === "user" && selectedUser !== "all" ? selectedUser : null
+            }
+          />
+        </div>
 
-
-        <h2 className="section-heading">Volume-based Metrics</h2>
+        <h2 className="section-heading">
+          Contributor Impact Map{" "}
+          {selectedRepo !== "All Teams" ? `(${selectedRepo})` : "(All Teams)"}
+        </h2>
 
         <div className="chart-card">
           <div style={{ height: "350px", position: "relative" }}>
-            <VolumeCharts
-              data={volumeData}
-              repos={
-                view === "team" || selectedUser === "all"
-                  ? "All"
-                  : selectedUser
-              }
-              user={
-                view === "user" && selectedUser !== "all"
-                  ? selectedUser
-                  : null
-              }
-            />
+            <ContributorImpactChart data={contributorImpactData} />
           </div>
         </div>
 
-      
-      {showSettings && (
-        <UserSetup
-          userId={authUser?.uid}
-          userDoc={userDoc}
-          availableRepos={availableRepos}
-          isSettingsMode={true}
-          onClose={() => setShowSettings(false)}
-          onComplete={(selectedPreferences) => {
-            // Update dashboard right after saving settings
-            const updatedUserDoc = {
-              ...userDoc,
-              trackedRepos: selectedPreferences.trackedRepos,
-              trackedMetrics: selectedPreferences.trackedMetrics,
-            };
+        {showSettings && (
+          <UserSetup
+            userId={authUser?.uid}
+            userDoc={userDoc}
+            availableRepos={availableRepos}
+            isSettingsMode={true}
+            onClose={() => setShowSettings(false)}
+            onComplete={(selectedPreferences) => {
+              // Update dashboard right after saving settings
+              const updatedUserDoc = {
+                ...userDoc,
+                trackedRepos: selectedPreferences.trackedRepos,
+                trackedMetrics: selectedPreferences.trackedMetrics,
+              };
 
-            setUserDoc(updatedUserDoc);
-            setShowSettings(false);
+              setUserDoc(updatedUserDoc);
+              setShowSettings(false);
 
-            if (selectedPreferences.trackedRepos.length > 0) {
-              setSelectedTeam(selectedPreferences.trackedRepos[0]);
-              setSelectedUserRepo(selectedPreferences.trackedRepos[0]);
-            }
-          }}
-        />
-      )}
+              if (selectedPreferences.trackedRepos.length > 0) {
+                setSelectedTeam(selectedPreferences.trackedRepos[0]);
+                setSelectedUserRepo(selectedPreferences.trackedRepos[0]);
+              }
+            }}
+          />
+        )}
       </main>
     </div>
-    
-  )};
+  );};

--- a/Frontend/src/utils/transformContributorData.js
+++ b/Frontend/src/utils/transformContributorData.js
@@ -1,0 +1,32 @@
+export const buildBubbleData = (data) => {
+  const contributors = {};
+
+  Object.values(data).forEach((repo) => {
+    // Issues
+    Object.entries(repo.issues || {}).forEach(([user, stats]) => {
+      if (!contributors[user]) contributors[user] = initUser(user);
+      contributors[user].issuesClosed += Number(stats.total_issues_closed) || 0;
+    });
+
+    // PRs
+    Object.entries(repo.pull_requests || {}).forEach(([user, stats]) => {
+      if (!contributors[user]) contributors[user] = initUser(user);
+      contributors[user].prsOpened += stats.total_prs_opened || 0;
+    });
+
+    // Commits
+    Object.entries(repo.commits || {}).forEach(([user, stats]) => {
+      if (!contributors[user]) contributors[user] = initUser(user);
+      contributors[user].commits += stats.total_commits || 0;
+    });
+  });
+
+  return Object.values(contributors);
+};
+
+const initUser = (name) => ({
+  name,
+  commits: 0,
+  issuesClosed: 0,
+  prsOpened: 0,
+});


### PR DESCRIPTION
# Description

Implemented a Contributor Impact Bubble Chart across the Home and TeamStats dashboards. This chart visualizes contributor performance using commits (experience), issues closed (impact), and PR activity (bubble size). The chart was integrated into the existing UI and replaces the previous volume-based chart for a more meaningful analysis.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested that the chart correctly had each bubble represent a contributor. Larger bubbles indicate more pull requests opened, while position reflects experience (commits) and impact (issues closed).
 
- [ ] Tested that the chart in the Team Stats page would correctly update depending on what team is selected

**Test Configuration**: 
* Language Version: 
* Webpage (if applicable): npm run dev 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

# Screenshot of Output
Please provide a screenshot of your output below (during all tests if applicable)
<img width="1512" height="768" alt="Screenshot 2026-04-30 at 2 07 03 PM" src="https://github.com/user-attachments/assets/f1ee5ae2-196e-44c9-b08f-894603d7a28e" />
<img width="1492" height="732" alt="Screenshot 2026-04-30 at 2 07 17 PM" src="https://github.com/user-attachments/assets/f7fd29cd-19f9-493d-aeec-29bf1200fa05" />

